### PR TITLE
Update jewelry improvement cost

### DIFF
--- a/src/js/crafting.js
+++ b/src/js/crafting.js
@@ -1166,9 +1166,6 @@ function calculateTotalMaterials()
           var impIdx = 1;
           for (impIdx = 1; impIdx <= improvementSelect.selectedIndex; impIdx++) {
             name = improvementMat[impIdx];
-            if (isJewelry)
-              count = impIdx;
-            else
               count = improvementLevels[impIdx].materialCount;
             if (improvementMats[name] == null)
               improvementMats[name] = count*qty;


### PR DESCRIPTION
As mentioned in https://github.com/rydog89/ESO-Crafting-Calculator/issues/1, the jewelry improvement cost is out of date. Update 40 changed it so that jewelry improvement works the same as other gear improvement (source: https://en.uesp.net/wiki/Online:Jewelry_Crafting#Platings).
This PR fixes jewelry improvement cost to use the same cost as other gear types, that is [2, 3, 4, 8].
Tested locally and works.